### PR TITLE
Implementing support for managing Gem ownership for the RubyGems registry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "faraday", "~> 2.7"
+gem "faraday-retry", "~> 2.2"
 gem "graphql-client", "~> 0.18"
 gem "netrc", "~> 0.11.0"
 gem "octokit", "~> 6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
     graphql (2.1.3)
       racc (~> 1.4)
     graphql-client (0.18.0)
@@ -124,6 +126,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  faraday (~> 2.7)
+  faraday-retry (~> 2.2)
   graphql-client (~> 0.18)
   netrc (~> 0.11.0)
   octokit (~> 6.1)

--- a/cli.thor
+++ b/cli.thor
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "thor"
 require "io/console"
+require_relative "cli/gems.rb"
 require_relative "cli/github.rb"
 require_relative "cli/issues.rb"
 require_relative "cli/labels.rb"

--- a/cli/gems.rb
+++ b/cli/gems.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "thor"
+require "io/console"
+
+dir_path = File.dirname(__FILE__)
+pattern = File.join(dir_path, "..", "lib", "**", "*rb")
+paths = Dir.glob(pattern)
+paths.each { |file| require(file) }
+
+class Samvera::Gems < Thor
+  attr_reader :client
+
+  desc("auth", "Authenticate against the RubyGems API")
+  option(:mfa, default: false, type: :boolean)
+  option(:uri, required: false)
+  option(:otp, required: false)
+  def auth
+    # Build the client for the RubyGems API
+    build_client(api_key:, mfa: options[:mfa], uri: options[:uri], otp: options[:otp])
+    client.gems
+
+    # This is merely to ensure that the client is authenticated
+    say("Successfully authenticated against the RubyGems API", :green)
+  end
+
+  desc("owners", "List the owners for a given Gem published to RubyGems")
+  option(:mfa, default: false, type: :boolean)
+  option(:uri)
+  option(:otp)
+
+  option(:name, required: true)
+  def owners
+    # Build the client for the RubyGems API
+    build_client(api_key:, mfa: options[:mfa], uri: options[:uri], otp: options[:otp])
+
+    gem_name = options[:name]
+    owners = client.find_owners_by(gem_name:)
+
+    say("The following users are owners for the Gem #{gem_name}:", :green)
+
+    owners.each do |owner|
+      say("#{owner.handle}", :yellow)
+    end
+  end
+
+  desc("add_owner", "Add an owner for a given Gem")
+  option(:mfa, default: false, type: :boolean)
+  option(:uri)
+  option(:otp)
+
+  option(:name, required: true)
+  option(:owner, required: true)
+  def add_owner
+    # Build the client for the RubyGems API
+    build_client(api_key:, mfa: options[:mfa], uri: options[:uri], otp: options[:otp])
+
+    gem_name = options[:name]
+    found = client.find_gem_by(name: gem_name)
+
+    say("Successfully resolved the Gem #{gem_name}", :green)
+
+    owner_email = options[:owner]
+    found.add_owner(email: owner_email)
+    say("Successfully added the owner #{owner_email} to the Gem #{gem_name}", :green)
+  end
+
+  desc("remove_owner", "Remove an owner for a given Gem")
+  option(:mfa, default: false, type: :boolean)
+  option(:uri)
+  option(:otp)
+
+  option(:name, required: true)
+  option(:owner, required: true)
+  def remove_owner
+    # Build the client for the RubyGems API
+    build_client(api_key:, mfa: options[:mfa], uri: options[:uri], otp: options[:otp])
+
+    gem_name = options[:name]
+    found = client.find_gem_by(name: gem_name)
+
+    say("Successfully resolved the Gem #{gem_name}", :green)
+
+    owner_email = options[:owner]
+    found.remove_owner(email: owner_email)
+    say("Successfully removed the owner #{owner_email} from the Gem #{gem_name}", :green)
+  end
+
+  no_commands do
+
+    def api_key
+      @api_key ||= STDIN.getpass("Please enter your RubyGems API key:")
+    end
+
+    def build_client(**args)
+      @client ||= Samvera::RubyGems::Client.new(**args)
+    end
+  end
+end

--- a/lib/samvera/rubygems/client.rb
+++ b/lib/samvera/rubygems/client.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative "gem"
+require "faraday"
+
+module Samvera
+  module RubyGems
+    class Client
+
+      def self.default_uri
+        URI("https://rubygems.org/api/v1/")
+      end
+
+      def initialize(api_key:, mfa: false, uri: nil, otp: nil)
+        @api_key = api_key
+        @uri = if uri.nil?
+                 self.class.default_uri
+               else
+                 URI(uri)
+               end
+
+        @mfa = mfa
+        @otp = otp
+
+        @http_client = Faraday.new(url: @uri.to_s, headers: build_headers)
+      end
+
+      def build_headers
+        built = {
+          "Accept" => "application/json",
+          "Content-Type" => "application/json",
+          "Authorization" => @api_key
+        }
+        built["OTP"] = @otp if mfa?
+        built
+      end
+
+      def mfa?
+        @mfa
+      end
+
+      def execute_delete_request(path:, **params)
+        response = @http_client.delete(path, **params)
+        raise_http_error(response:) unless response.success?
+
+        response
+      end
+
+      def execute_post_request(path:, **params)
+        params_json = JSON.generate(params)
+        response = @http_client.post(path, params_json)
+        raise_http_error(response:) unless response.success?
+
+        response
+      end
+
+      def execute_get_request(path:)
+        response = @http_client.get(path)
+        raise_http_error(response:) unless response.success?
+
+        response
+      end
+
+      # `Index rubygems` scope must be enabled for the RubyGems API key
+      def gems
+        path = "gems.json"
+        response = execute_get_request(path:)
+        built = Gem.build_all_from_response(client: self, response:)
+        built
+      end
+
+      # `Index rubygems` scope must be enabled for the RubyGems API key
+      def find_gem_by(name:)
+        path = "gems/#{name}.json"
+        response = execute_get_request(path:)
+        built = Gem.build_from_response(client: self, response:)
+        built
+      end
+
+      # `Index rubygems` scope must be enabled for the RubyGems API key
+      def find_owners_by(gem_name:)
+        path = "gems/#{gem_name}/owners.json"
+        response = execute_get_request(path:)
+        built = User.build_all_from_response(client: self, response:)
+        built
+      end
+
+      private
+
+      def raise_http_error(response:)
+        case response.status
+        when 401, 403
+          raise(StandardError, "Not authorized to #{response.env.method} request for #{response.env.url}: #{response.body}")
+        when 404
+          raise(StandardError, "HTTP resource #{response.env.url} could not be found.")
+        else
+          raise(StandardError, "Error #{response.status} transmitting #{response.env.method} request for #{response.env.url}: #{response.body}")
+        end
+      end
+    end
+  end
+end

--- a/lib/samvera/rubygems/gem.rb
+++ b/lib/samvera/rubygems/gem.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "resource"
+
+module Samvera
+  module RubyGems
+    class Gem < Resource
+      attr_accessor :authors,
+                    :bug_tracker_uri,
+                    :changelog_uri,
+                    :dependencies,
+                    :documentation_uri,
+                    :downloads,
+                    :funding_uri,
+                    :gem_uri,
+                    :homepage_uri,
+                    :info,
+                    :licenses,
+                    :mailing_list_uri,
+                    :metadata,
+                    :name,
+                    :platform,
+                    :project_uri,
+                    :sha,
+                    :source_code_uri,
+                    :version,
+                    :version_created_at,
+                    :version_downloads,
+                    :wiki_uri,
+                    :yanked
+
+      def add_owner(email:)
+        path = "gems/#{name}/owners"
+        @client.execute_post_request(path:, email:)
+        self
+      end
+
+      def remove_owner(email:)
+        path = "gems/#{name}/owners"
+        @client.execute_delete_request(path:, email:)
+        self
+      end
+    end
+  end
+end

--- a/lib/samvera/rubygems/resource.rb
+++ b/lib/samvera/rubygems/resource.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Samvera
+  module RubyGems
+    class Resource
+
+      def self.build_all_from_response(client:, response:)
+        parsed = JSON.parse(response.body)
+        built = parsed.map do |attributes|
+          new(client:, **attributes)
+        end
+        built
+      end
+
+      def self.build_from_response(client:, response:)
+        attributes = JSON.parse(response.body)
+        new(client:, **attributes)
+      end
+
+      def initialize(client:, **attributes)
+        @client = client
+
+        #require 'pry-byebug'
+        #binding.pry
+        attributes.each do |key, value|
+          signature = "#{key}="
+          self.public_send(signature, value)
+        end
+      end
+    end
+  end
+end

--- a/lib/samvera/rubygems/user.rb
+++ b/lib/samvera/rubygems/user.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "resource"
+
+module Samvera
+  module RubyGems
+    class User < Resource
+      attr_accessor :email,
+                    :handle,
+                    :id
+
+    end
+  end
+end


### PR DESCRIPTION
This also begins to replace the usage of `Net::HTTP` with `Faraday` for the HTTP client